### PR TITLE
Switch to Alpine base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Multistage build to reduce image size and increase security
-FROM node:12-buster-slim AS build
+FROM node:12-alpine AS build
 
 # Install requirements to clone repository and install deps
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq git
+RUN apk add --no-cache git
 RUN npm install -g bower
 
 # Create folder for cryptpad
@@ -12,7 +12,7 @@ WORKDIR /cryptpad
 # Get cryptpad from repository submodule
 COPY cryptpad /cryptpad
 
-RUN sed -i "s/\/\/httpAddress: \x27::\x27/httpAddress: \x270.0.0.0\x27/" /cryptpad/config/config.example.js
+RUN sed -i "s@//httpAddress: '::'@httpAddress: '0.0.0.0'@" /cryptpad/config/config.example.js
 
 # Install dependencies
 RUN npm install --production \
@@ -20,11 +20,11 @@ RUN npm install --production \
     && bower install --allow-root
 
 # Create actual cryptpad image
-FROM node:12-buster-slim
+FROM node:12-alpine
 
 # Create user and group for cryptpad so it does not run as root
-RUN groupadd cryptpad -g 4001
-RUN useradd cryptpad -u 4001 -g 4001 -d /cryptpad
+RUN addgroup -g 4001 -S cryptpad \
+    && adduser -u 4001 -S -D -g 4001 -H -h /cryptpad cryptpad
 
 # Copy cryptpad with installed modules
 COPY --from=build --chown=cryptpad /cryptpad /cryptpad


### PR DESCRIPTION
> Alpine Linux is a Linux distribution built around musl libc and BusyBox. The image is only 5 MB in size and has access to a package repository that is much more complete than other BusyBox based images. This makes Alpine Linux a great image base for utilities and even production applications.

~ https://hub.docker.com/_/alpine

As a side effect the image becomes ~100MB smaller.