### PR TITLE
Nginx - hide server tokens

### DIFF
--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -33,7 +33,7 @@ RUN set -x \
 # Copy nginx conf from official image
 COPY --from=nginx:latest /etc/nginx /etc/nginx
 
-# Change nginx and disable server tokens
+# Change nginx user and disable server tokens
 RUN sed -i -e 's@\(^user\).*[^;]@\1 www-data@' \
     -e "/default_type/a \\    server_tokens off;" /etc/nginx/nginx.conf
 

--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -33,8 +33,9 @@ RUN set -x \
 # Copy nginx conf from official image
 COPY --from=nginx:latest /etc/nginx /etc/nginx
 
-# Debian uses www-data user instead of nginx
-RUN sed -i 's@\(^user\).*[^;]@\1 www-data@' /etc/nginx/nginx.conf
+# Change nginx and disable server tokens
+RUN sed -i -e 's@\(^user\).*[^;]@\1 www-data@' \
+    -e "/default_type/a \\    server_tokens off;" /etc/nginx/nginx.conf
 
 # Copy cryptpad with installed modules
 COPY --from=build --chown=cryptpad /cryptpad /cryptpad

--- a/Dockerfile-nginx-alpine
+++ b/Dockerfile-nginx-alpine
@@ -34,6 +34,9 @@ RUN set -x \
 # Copy nginx conf from official image
 COPY --from=nginx:latest /etc/nginx /etc/nginx
 
+# Disable server tokens
+RUN sed -i "/default_type/a \\    server_tokens off;" /etc/nginx/nginx.conf
+
 # Copy cryptpad with installed modules
 COPY --from=build --chown=cryptpad /cryptpad /cryptpad
 


### PR DESCRIPTION
Add a sed expression to Dockerfile-nginx add `server_tokens off;` in `nginx.conf`.  

This prevents Nginx from adding the version number to the `server` HTTP header.  
