### PR TITLE
Add workaround to prevent header duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To disable HTTP2 set the environment variable `CPAD_HTTP2_DISABLE` to `true`.
 | `CPAD_TLS_KEY` | Path to TLS private key file | No | None |
 | `CPAD_TLS_DHPARAM` | Path to Diffie-Hellman parameters file | No | `/etc/nginx/dhparam.pem` |
 | `CPAD_HTTP2_DISABLE` | Disable HTTP2 | No | `false` |
-| `CPAD_HIDE_PROXY_HEADERS` | Hide HTTP headers before proxying to FPM (This is a temporary workaround to avoid header duplicaiton until issue is fixed upstream in CryptPad) | No | `false` |
+| `CPAD_HIDE_PROXY_HEADERS` | Hide HTTP headers before proxying to FPM (This is a temporary workaround to avoid header duplication until issue is fixed upstream in CryptPad) | No | `false` |
 
 #### Usage
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ To disable HTTP2 set the environment variable `CPAD_HTTP2_DISABLE` to `true`.
 | `CPAD_TLS_KEY` | Path to TLS private key file | No | None |
 | `CPAD_TLS_DHPARAM` | Path to Diffie-Hellman parameters file | No | `/etc/nginx/dhparam.pem` |
 | `CPAD_HTTP2_DISABLE` | Disable HTTP2 | No | `false` |
+| `CPAD_HIDE_PROXY_HEADERS` | Hide HTTP headers before proxying to FPM (This is a temporary workaround to avoid header duplicaiton until issue is fixed upstream in CryptPad) | No | `false` |
 
 #### Usage
 
@@ -134,3 +135,5 @@ A workaround is to disable HTTP2 by setting the `CPAD_HTTP2_DISABLE` environment
 
 ##### Nginx version not working with some browser configurations  
 See [https://github.com/xwiki-labs/cryptpad/issues/633]  
+A workaround has been added to the `docker-entrypoint.sh` script.  
+Enable it by setting `CPAD_HIDE_PROXY_HEADERS` to `true`.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -132,6 +132,19 @@ if [ ! -f "${CPAD_NGINX_CPAD_CONF:=/etc/nginx/conf.d/cryptpad.conf}" ]; then
     sed -i  -e "s@\(^.*\) \+http2\(.*$\)@\1\2@" $CPAD_NGINX_CPAD_CONF
   fi
 
+  if [ "${CPAD_HIDE_PROXY_HEADERS:-false}" = "true" ]; then
+    sed -i '/\/api\/config {/ a \
+        proxy_hide_header Access-Control-Allow-Origin;\
+        proxy_hide_header Cache-Control;\
+        proxy_hide_header Content-Security-Policy;\
+        proxy_hide_header Cross-Origin-Embedder-Policy;\
+        proxy_hide_header Cross-Origin-Opener-Policy;\
+        proxy_hide_header Cross-Origin-Resource-Policy;\
+        proxy_hide_header X-Content-Type-Options;\
+        proxy_hide_header X-XSS-Protection;\
+        ' $CPAD_NGINX_CPAD_CONF
+  fi
+
   ## WIP
   # If cryptad conf isn't provided
   # if [ ! -f "$CPAD_CONF" ]; then


### PR DESCRIPTION
Less ugly than expected and works :smile: 

Basically adds an env variable `CPAD_HIDE_PROXY_HEADERS` (might be misnamed) to run a sed block to insert the workaround solution described here: https://github.com/xwiki-labs/cryptpad/issues/633

Fixes #14 
