### PR TITLE
Use "npm start" to allow for proper stopping of container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ VOLUME /cryptpad/datastore
 EXPOSE 3000 3001
 
 # Run cryptpad on startup
-CMD ["server.js"]
+CMD ["npm", "start"]

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -47,4 +47,4 @@ VOLUME /cryptpad/datastore
 EXPOSE 3000 3001
 
 # Run cryptpad on startup
-CMD ["server.js"]
+CMD ["npm", "start"]


### PR DESCRIPTION
Previously, when stopping the container the Term signal wouldn't cause the container to stop. After the timeout docker kills the container.
Using `npm start` seems to work.
The solution is taken from https://stackoverflow.com/a/57473861