### PR TITLE
include an 'installMethod' property in server telemetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /cryptpad
 COPY cryptpad /cryptpad
 
 RUN sed -i "s@//httpAddress: '::'@httpAddress: '0.0.0.0'@" /cryptpad/config/config.example.js
+RUN sed -i "s@installMethod: 'unspecified'@installMethod: 'docker'@" /cryptpad/config/config.example.js
 
 # Install dependencies
 RUN npm install --production \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -13,6 +13,7 @@ WORKDIR /cryptpad
 COPY cryptpad /cryptpad
 
 RUN sed -i "s@//httpAddress: '::'@httpAddress: '0.0.0.0'@" /cryptpad/config/config.example.js
+RUN sed -i "s@installMethod: 'unspecified'@installMethod: 'docker-alpine'@" /cryptpad/config/config.example.js
 
 # Install dependencies
 RUN npm install --production \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -71,7 +71,7 @@ if [ ! -f "${CPAD_NGINX_CPAD_CONF:=/etc/nginx/conf.d/cryptpad.conf}" ]; then
   # Change nginx document root
   sed -i "s@\(root\) */.*\([^;]\)@\1 $CPAD_HOME@" $CPAD_NGINX_CPAD_CONF
 
-  # Wether or not Nginx should terminate TLS (defaults to true)
+  # Whether or not Nginx should terminate TLS (defaults to true)
   if [ -n "$CPAD_TLS_CERT" \
     -a -n "$CPAD_TLS_KEY" ]; then
 


### PR DESCRIPTION
This PR depends on [this commit](https://github.com/xwiki-labs/cryptpad/commit/f5e91ef3ef4c34c97178825c06fec2e81808d741) in the platform repository which will be merged into the 4.8.0 release.

It rewrites the `installMethod` attribute which has been added to the example config such that server telemetry indicates the install method that was used to create the instance (`"docker"` or `"docker-alpine"`).

This is in response to #25 

It also corrects a typo, changing the use of _"Wether"_ (Noun: a castrated ram) to _"Whether"_ (Conjunction: expressing a doubt or choice between alternatives).