### PR TITLE
Clarify disclaimer, warranty and support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This repository has been created as part of an ongoing effort to separate docker
 
 The officially recommended deployment method is to use the `example.nginx.conf` file provided by the core repo and to manage updates directly on the host system using `git`, `npm` (as provided by [nvm](https://github.com/nvm-sh/nvm)) and `bower`.
 
-Docker images and their supporting configuration files are provided as a community effort by those using them, with support provided by the core development team on a _best-effort_ basis. Keep in mind that the core team neither uses nor tests Docker images, so your results may vary.
+## 🚧 Disclaimer
+
+The Docker images here and their supporting configuration files are provided *as is*, without warranty, as a *community effort*. Support is provided by the community and CryptPad developers on a _best-effort_ basis. Please keep in mind, that the core team neither uses nor tests these Docker images, so your results may vary.
 
 ## Migration
 Please see the [migration guide](MIGRATION.md) for further information on switching to this repository.  


### PR DESCRIPTION
This updates the README to clarify the relation of the core CryptPad development team and expectations towards support and warranty.

This has come up in https://github.com/xwiki-labs/cryptpad-docker/issues/37#issuecomment-1037688646 ff.