### PR TITLE
Update to 4.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multistage build to reduce image size and increase security
-FROM node:12-buster-slim AS build
+FROM node:16-buster-slim AS build
 
 # Install requirements to clone repository and install deps
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq git
@@ -21,7 +21,7 @@ RUN npm install --production \
     && bower install --allow-root
 
 # Create actual cryptpad image
-FROM node:12-buster-slim
+FROM node:16-buster-slim
 
 # Create user and group for cryptpad so it does not run as root
 RUN groupadd cryptpad -g 4001

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,5 +1,5 @@
 # Multistage build to reduce image size and increase security
-FROM node:12-alpine AS build
+FROM node:16-alpine AS build
 
 # Install requirements to clone repository and install deps
 RUN apk add --no-cache git
@@ -21,7 +21,7 @@ RUN npm install --production \
     && bower install --allow-root
 
 # Create actual cryptpad image
-FROM node:12-alpine
+FROM node:16-alpine
 
 # Create user and group for cryptpad so it does not run as root
 RUN addgroup -g 4001 -S cryptpad \

--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,6 +1,6 @@
 # Multistage build to reduce image size and increase security
 
-FROM node:12-buster-slim AS build
+FROM node:16-buster-slim AS build
 
 # Install requirements to clone repository and install deps
 RUN apt-get update \
@@ -18,7 +18,7 @@ RUN npm install --production \
     && bower install --allow-root
 
 # Create actual cryptpad image
-FROM node:12-buster-slim
+FROM node:16-buster-slim
 
 RUN set -x \
     # Create users and groups for cryptpad

--- a/Dockerfile-nginx-alpine
+++ b/Dockerfile-nginx-alpine
@@ -1,6 +1,6 @@
 # Multistage build to reduce image size and increase security
 
-FROM node:12-alpine AS build
+FROM node:16-alpine AS build
 
 # Install requirements to clone repository and install deps
 RUN apk add --no-cache git \
@@ -17,7 +17,7 @@ RUN npm install --production \
     && bower install --allow-root
 
 # Create actual cryptpad image
-FROM node:12-alpine
+FROM node:16-alpine
 
 RUN set -x \
     # Create users and groups for nginx and cryptpad


### PR DESCRIPTION
Fixes #48.

4.14.0 does not compile with node 12 anymore. Release notes suggests to update to node 16 so doing this as well here.