### PR TITLE
Fix nginx conf for 5.2.1

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -106,15 +106,17 @@ if [ ! -f "${CPAD_NGINX_CPAD_CONF:=/etc/nginx/conf.d/cryptpad.conf}" ]; then
     # Make Nginx listen on 80 in plaintext
     # and comment out all ssl related options
     sed -i  -e "s@\(^.*\) \+443 ssl\(.*$\)@\1 80\2@" \
-            -e "s@[^#]ssl_@ #ssl_@g" $CPAD_NGINX_CPAD_CONF
+            -e 's/^[^#]*ssl/#&/' \
+            -e 's/^[^#]*letsencrypt/#&/' \
+	    $CPAD_NGINX_CPAD_CONF
   fi
 
   # Should Nginx use http_realip_module
   if [ -n "${CPAD_TRUSTED_PROXY:=}" ]; then
     # Set trusted proxy
-    sed -i  -e "/listen/ G" \
-    -e "/listen/ a \   \ # Set trusted proxy and header containing real client IP" \
-    -e "/listen/ a \   \ set_real_ip_from  $CPAD_TRUSTED_PROXY;" $CPAD_NGINX_CPAD_CONF
+    sed -i  -e "/listen 80/ G" \
+    -e "/listen 80/ a \   \ # Set trusted proxy and header containing real client IP" \
+    -e "/listen 80/ a \   \ set_real_ip_from  $CPAD_TRUSTED_PROXY;" $CPAD_NGINX_CPAD_CONF
 
     # Set header to get real client IP from
     if [ -n "${CPAD_REALIP_HEADER:-}" ]; then


### PR DESCRIPTION
turns out example.nginx.conf have been updated with new ssl / lentsencrypt and this lead to a non working nginx.conf file

```
 git diff 5.1.0 5.2.1 -- example.nginx.conf
diff --git a/docs/example.nginx.conf b/docs/example.nginx.conf
index 1f71fc8b7..16a26872c 100644
--- a/docs/example.nginx.conf
+++ b/docs/example.nginx.conf
@@ -6,6 +6,10 @@

 server {
     listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    # Let's Encrypt webroot
+    include letsencrypt-webroot;
```