### PR TITLE
Remove SSL configuration from the nginx configuration when TLS is not set

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -106,7 +106,9 @@ if [ ! -f "${CPAD_NGINX_CPAD_CONF:=/etc/nginx/conf.d/cryptpad.conf}" ]; then
     # Make Nginx listen on 80 in plaintext
     # and comment out all ssl related options
     sed -i  -e "s@\(^.*\) \+443 ssl\(.*$\)@\1 80\2@" \
-            -e "s@[^#]ssl_@ #ssl_@g" $CPAD_NGINX_CPAD_CONF
+            -e "s@[^#]ssl_@ #ssl_@g" \
+            -e "s@include letsencrypt-webroot;@ #include letsencrypt-webroot;@g" \
+            -e "s@listen .*443 ssl;@ #listen [::]:443 ssl@g" $CPAD_NGINX_CPAD_CONF
   fi
 
   # Should Nginx use http_realip_module


### PR DESCRIPTION
For some reason, my sed command does not work for the listen 443.